### PR TITLE
修改modal不支持多class的bug

### DIFF
--- a/src/components/modal/index.vue
+++ b/src/components/modal/index.vue
@@ -1,6 +1,6 @@
 <template lang="html">
     <div class="xcui-modal-wrapper xcui-modal-mask" @click="maskClose" v-el:modal-mask v-show="show">
-        <div class="xcui-modal" tabindex="-1" @keydown.esc="cancel" :style="style" :class="[sizeClass,className]">
+        <div class="xcui-modal" tabindex="-1" @keydown.esc="cancel" :style="style" :class="modalClass">
             <div class="xcui-modal-header" v-if="showHeader">
                 <slot name="header">
                     <span class="xcui-modal-title">{{title}}</span>
@@ -116,6 +116,9 @@ export default {
     computed: {
         sizeClass() {
             return `xcui-modal-size-${this.size}`;
+        },
+        modalClass() {
+            return `${this.sizeClass} ${this.className}`;
         }
     },
     methods: {


### PR DESCRIPTION
让modal支持class-name="classA classB"