### PR TITLE
修复table-column无法动态赋值问题

### DIFF
--- a/src/components/table/src/table-column.vue
+++ b/src/components/table/src/table-column.vue
@@ -1,6 +1,7 @@
 <template></template>
 
 <script>
+const SINGLE_LINE_CLASS_NAME = 'x-table-td-single-line';
 export default {
     name: 'XTableColumn',
 
@@ -30,32 +31,36 @@ export default {
             }
         }
     },
-
+    data() {
+        return {
+            columnOrder: 0
+        };
+    },
     mounted() {
+        // this.$options.render = h => h('div', this.$slots.default);
         let parent = this.$parent;
-        while (parent && parent.$options.name !== 'XTable') {
-            parent = parent.$parent;
+        let origin = this.$parent;
+        while (origin && origin.$options.name !== 'XTable') {
+            origin = origin.$parent;
         }
-
-        this.table = parent;
-
+        this.table = origin;
+        let isSubColumn = parent !== origin;
         const slots = this.$scopedSlots;
 
         if (this.type) {
             this.table.rowKey = this.prop;
         }
 
-        const SINGLE_LINE_CLASS_NAME = 'x-table-td-single-line';
         let tdClassName = this.singleLine ? this.className + ' ' + SINGLE_LINE_CLASS_NAME : this.className;
 
-        // 将数据配置存到 table 上
-        this.table.columns.push({
+        let column = {
             title: this.title,
             type: this.type || 'normal',
             prop: this.prop,
             width: this.width,
             className: tdClassName,
             singleLine: this.singleLine,
+            children: [],
             // tbody 中每个 td 内的 render 方法
             render: slots.default
                 // 如果 <x-table-column> 内有 template，按照 template 内的来渲染
@@ -66,7 +71,69 @@ export default {
                     // 直接返回内容
                     return dataItem[columnItem.prop];
                 }
-        });
+        };
+        this.columnConfig = column;
+        let columnIndex;
+
+        if (!isSubColumn) {
+            columnIndex = [].indexOf.call(parent.$refs.hiddenColumns.children, this.$el);
+        }
+        else {
+            columnIndex = [].indexOf.call(parent.$el.children, this.$el);
+        }
+
+        this.insertColumn(this.table, column, columnIndex, isSubColumn ? parent.columnConfig : null);
+    },
+    watch: {
+        title(val) {
+            this.updateColumn('title');
+        },
+        prop(val) {
+            this.updateColumn('prop');
+        },
+        type(val) {
+            this.updateColumn('type');
+        },
+        width(val) {
+            this.updateColumn('width');
+        },
+        className(val) {
+            let tdClassName = this.singleLine ? this.className + ' ' + SINGLE_LINE_CLASS_NAME : this.className;
+            this.updateColumn('className', tdClassName);
+        },
+        singleLine(val) {
+            this.updateColumn('singleLine');
+        }
+    },
+    methods: {
+        insertColumn(table, column, index, parent) {
+            let array = table.columns;
+            if (parent) {
+                array = parent.children;
+                if (!array) {
+                    array = parent.children = [];
+                }
+            }
+            if (typeof index !== 'undefined') {
+                array.splice(index, 0, column);
+                this.columnOrder = index;
+            }
+            else {
+                this.columnOrder = array.push(column) - 1;
+            }
+        },
+        updateColumn(name, customVal) {
+            let value = customVal || this[name];
+            if (value) {
+                this.$set(this.table.columns[this.columnOrder], name, value);
+            }
+        },
+        removeColumn() {
+            this.table.columns.splice(this.columnOrder, 1);
+        }
+    },
+    destroyed() {
+        this.removeColumn();
     }
 };
 </script>

--- a/src/components/table/src/table.vue
+++ b/src/components/table/src/table.vue
@@ -4,6 +4,7 @@
             'x-table-bordered': bordered,
             'x-table-striped': striped
             }">
+            <div class="hidden-columns" ref="hiddenColumns"><slot></slot></div>
             <colgroup>
                 <col
                     v-for="item in columns"
@@ -24,7 +25,7 @@
                 @changeCheckbox="onChangeCheckbox"
                 @changeRadio="onChangeRadio"
             />
-            <slot></slot>
+            <!-- <slot></slot> -->
         </table>
         <div class="x-table-empty-tip" v-if="data.length === 0">
             {{emptyTip}}


### PR DESCRIPTION
当表头组件存在依据动态数据传入时，通过监听表头属性变化，以及通过table组件预留的slot保存并定位当前表头组件的加载位置，及时并准确同步修改待渲染的columns列数组数据，达到表头动态赋值的效果。