### PR TITLE
fix modal demo error && add input type props

### DIFF
--- a/src/components/input/src/input.vue
+++ b/src/components/input/src/input.vue
@@ -54,7 +54,12 @@
             form: String,
             maxlength: Number,
             minlength: Number,
-            iconClick: Function
+            iconClick: Function,
+            type: {
+                default: 'text',
+                type: String,
+                validator: val => ['text', 'password'].indexOf(val) >= 0
+            }
         },
         data() {
             return {

--- a/src/demos/input.vue
+++ b/src/demos/input.vue
@@ -120,6 +120,7 @@
 |v-model|String, Number|无|和`v-model`的绑定值|必选||
 |size|String|无|输入框大小|可选|`large`, `small`|
 |placeholder|String|无|原生属性，输入框默认文本，用于提示|可选||
+|type|String|无|原生属性，输入框类型|可选|`text`, `password`|
 |disabled|Boolean|false|是否禁用|可选||
 |icon|String|无|输入框右侧图标名称|可选||
 |readonly|Boolean|false|原生属性，是否只读|可选||

--- a/src/demos/modal.vue
+++ b/src/demos/modal.vue
@@ -21,7 +21,7 @@
     export default {
         data() {
             return {
-                modal1: true
+                modal1: false
             }
         }
     }
@@ -66,9 +66,9 @@
     export default {
         data() {
             return {
-                modal2: true,
-                modal3: true,
-                modal4: true
+                modal2: false,
+                modal3: false,
+                modal4: false
             }
         },
         methods: {
@@ -117,8 +117,8 @@
         data() {
             return {
                 isLoading: false,
-                modal5: true,
-                modal6: true
+                modal5: false,
+                modal6: false
             }
         }
     }


### PR DESCRIPTION
1. 修复modal的demo值为true(实际应为false)
2. input组件增加type选项，支持`text` && `password`