### PR TITLE
column customize

### DIFF
--- a/demos/components/table.vue
+++ b/demos/components/table.vue
@@ -449,7 +449,7 @@
 
 ## 列模板自定义
 
-::: demo 可以自己配置列内容。
+::: demo 可以自己配置列内容以及表头内容，未命名模版为列内容，设置名称为“column-header-slot”则为表头自定义模版，无该模版则默认显示title文案。
 
 ```html
 <tpl>
@@ -469,6 +469,13 @@
                 title="地址"
                 prop="address"
             >
+            <template scope="props" slot="column-header-slot">
+                {{props.columnItem.title}}
+                <x-tooltip content="Sample Text" title="Title">
+                        <x-icon name="help-circled" size="16"></x-icon>
+                </x-tooltip>
+            </template>
+
             </x-table-column>
             <x-table-column
                 title="职业"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "xcui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",

--- a/src/components/table/src/table-column.vue
+++ b/src/components/table/src/table-column.vue
@@ -70,6 +70,13 @@ export default {
                 : ({dataItem, columnItem}) => {
                     // 直接返回内容
                     return dataItem[columnItem.prop];
+                },
+            headerRender: slots['column-header-slot']
+                ? args => {
+                    return slots['column-header-slot'](args);
+                }
+                : () => {
+                    return this.title;
                 }
         };
         this.columnConfig = column;

--- a/src/components/table/src/table.vue
+++ b/src/components/table/src/table.vue
@@ -4,7 +4,7 @@
             'x-table-bordered': bordered,
             'x-table-striped': striped
             }">
-            <div class="hidden-columns" ref="hiddenColumns"><slot></slot></div>
+            <div class="x-table-hidden" ref="hiddenColumns"><slot></slot></div>
             <colgroup>
                 <col
                     v-for="item in columns"

--- a/src/components/table/src/thead.js
+++ b/src/components/table/src/thead.js
@@ -44,9 +44,15 @@ export default {
                                     );
                                 case 'normal':
                                 default:
+                                    let content = columnItem.headerRender.call(
+                                        this,
+                                        {
+                                            columnItem
+                                        }
+                                    );
                                     return (
                                         <th>
-                                            {columnItem.title}
+                                            {content}
                                         </th>
                                     );
                             }

--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -56,4 +56,7 @@
         font-size: 20px;
         text-align: center;
     }
+    &-hidden{
+        display: none;
+    }
 }


### PR DESCRIPTION
增加表头自定义功能，表头内元素设置名称为“column-header-slot”则为表头自定义模版