### PR TITLE
update build due to webpack3 issues

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -31,12 +31,13 @@ var hotMiddleware = require('webpack-hot-middleware')(compiler, {
   heartbeat: 2000
 })
 // force page reload when html-webpack-plugin template changes
-compiler.plugin('compilation', function (compilation) {
-  compilation.plugin('html-webpack-plugin-after-emit', function (data, cb) {
-    hotMiddleware.publish({ action: 'reload' })
-    cb()
-  })
-})
+// temporory remove because webpack3 issue https://github.com/vuejs-templates/webpack/issues/751
+// compiler.plugin('compilation', function (compilation) {
+//   compilation.plugin('html-webpack-plugin-after-emit', function (data, cb) {
+//     hotMiddleware.publish({ action: 'reload' })
+//     cb()
+//   })
+// })
 
 // proxy api requests
 Object.keys(proxyTable).forEach(function (context) {


### PR DESCRIPTION
when html-webpack-plugin works with webpack3 it always trigger `html-webpack-plugin-after-emit` hook, so HMR should not work. 

see issue https://github.com/vuejs-templates/webpack/issues/751
