### PR TITLE
table debug

### DIFF
--- a/src/components/table/src/table-column.vue
+++ b/src/components/table/src/table-column.vue
@@ -53,6 +53,7 @@ export default {
         if (this.type) {
             this.table.rowKey = this.prop;
         }
+        let thClassName = this.singleLine ? SINGLE_LINE_CLASS_NAME : '';
         let tdClassName = this.singleLine ? this.className + ' ' + SINGLE_LINE_CLASS_NAME : this.className;
         let column = {
             title: this.title,
@@ -60,6 +61,7 @@ export default {
             fixed: this.fixed || '',
             prop: this.prop,
             width: this.width,
+            thClassName: thClassName,
             className: tdClassName,
             singleLine: this.singleLine,
             children: [],
@@ -140,7 +142,7 @@ export default {
         removeColumn() {
             let parent = !this.isSubColumn ? this.table.columns : this.$parent.columnConfig.children;
             let curIndex = parent.indexOf(this.columnConfig);
-            parent.splice(curIndex, 1); 
+            parent.splice(curIndex, 1);
         }
     },
     destroyed() {

--- a/src/components/table/src/table.vue
+++ b/src/components/table/src/table.vue
@@ -213,14 +213,13 @@
                 return dataMap;
             },
             bodyStyle() {
-                let style = {};
+                let style = {
+                    'top': +this.headerHeight + 'px'
+                };
                 if (this.height) {
-                    style = {
-                        'max-height': (+this.height - this.headerHeight) + 'px'
-                    };
-                    return style;
+                    style['max-height'] = (+this.height - this.headerHeight) + 'px';
                 }
-                return '';
+                return style;
             },
             tableStyle() {
                 let style = {};
@@ -243,14 +242,13 @@
                 return style;
             },
             fixedBodyStyle() {
-                    let style = {}
+                    let style = {
+                        'top': +this.headerHeight + 'px'
+                    };
                     if (this.height) {
-                        style = {
-                            'max-height': (+this.height - this.headerHeight - this.scrollbarHeight) + 'px'
-                        };
-                        return style;
+                        style['max-height'] = (+this.height - this.headerHeight - this.scrollbarHeight) + 'px';
                     }
-                    return '';
+                    return style;
             },
             fixedLeftWidth() {
                 if (this.columns.length > 0 && this.columns[0].width) {
@@ -310,6 +308,11 @@
                     this.scrollbarHeight = this.$refs.bodyWrapper.offsetHeight - this.$refs.bodyWrapper.clientHeight;
                 });
             },
+            columns() {
+                this.$nextTick(() => {
+                    this.headerHeight = this.$refs.headerWrapper.offsetHeight;
+                });
+            },
             initialSelectedValue(value) {
                 this.selectedValue = value;
             },
@@ -322,13 +325,6 @@
                 this.headerHeight = this.$refs.headerWrapper.offsetHeight;
                 this.bodyHeight = this.$refs.bodyWrapper.offsetHeight;
                 this.scrollbarHeight = this.$refs.bodyWrapper.offsetHeight - this.$refs.bodyWrapper.clientHeight;
-                this.$refs.bodyWrapper.style.top = +this.headerHeight + 'px';
-                if (this.$refs.fixedBodyWrapper) {
-                    this.$refs.fixedBodyWrapper.style.top = +this.headerHeight + 'px';
-                }
-                if (this.$refs.rightFixedBodyWrapper) {
-                    this.$refs.rightFixedBodyWrapper.style.top = +this.headerHeight + 'px';
-                }
             });
             this.bindEvents();
         },

--- a/src/components/table/src/thead.js
+++ b/src/components/table/src/thead.js
@@ -21,7 +21,7 @@ export default {
         },
         convertToRows(originColumns) {
             let maxLevel = 1;
-            //对所有嵌套列数据标记列层级与子列跨度
+            // 对所有嵌套列数据标记列层级与子列跨度
             const traverse = (column, parent) => {
                 if (parent) {
                     column.level = parent.level + 1;
@@ -53,7 +53,7 @@ export default {
             }
 
             const allColumns = this.getAllColumns(originColumns);
-            //按列的层级排列表头数组
+            // 按列的层级排列表头数组
             allColumns.forEach((column) => {
                 if (!column.children || column.children.length === 0) {
                     column.rowSpan = maxLevel - column.level + 1;
@@ -66,7 +66,7 @@ export default {
 
             return rows;
         },
-        //取出所有嵌套列数据
+        // 取出所有嵌套列数据
         getAllColumns(columns) {
             const result = [];
             columns.forEach((column) => {
@@ -96,6 +96,7 @@ export default {
                                             return (
                                                 <th colspan={ columnItem.colSpan }
                                                 rowspan={ columnItem.rowSpan }
+                                                 class={columnItem.thClassName}
                                                 >
                                                     <x-checkbox
                                                         indeterminate={this.selectedStatus === 'partial'}
@@ -106,7 +107,7 @@ export default {
                                             );
                                         case 'radio':
                                             return (
-                                                <th></th>
+                                                <th class={columnItem.thClassName}></th>
                                             );
                                         case 'normal':
                                         default:
@@ -119,6 +120,7 @@ export default {
                                             return (
                                                 <th colspan={ columnItem.colSpan }
                                                 rowspan={ columnItem.rowSpan }
+                                                class={columnItem.thClassName}
                                                 >
                                                     {content}
                                                 </th>

--- a/src/components/table/src/thead.js
+++ b/src/components/table/src/thead.js
@@ -91,12 +91,18 @@ export default {
                         <tr>
                             {
                                 columns.map(columnItem => {
+                                    let content = columnItem.headerRender.call(
+                                        this, {
+                                            columnItem
+                                        }
+                                    );
                                     switch (columnItem.type) {
                                         case 'selection':
                                             return (
                                                 <th colspan={ columnItem.colSpan }
-                                                rowspan={ columnItem.rowSpan }
-                                                 class={columnItem.thClassName}
+                                                    rowspan={ columnItem.rowSpan }
+                                                    class={columnItem.thClassName}
+                                                    title={columnItem.singleLine ? content : ''}
                                                 >
                                                     <x-checkbox
                                                         indeterminate={this.selectedStatus === 'partial'}
@@ -107,20 +113,18 @@ export default {
                                             );
                                         case 'radio':
                                             return (
-                                                <th class={columnItem.thClassName}></th>
+                                                <th
+                                                    class={columnItem.thClassName}
+                                                    title={columnItem.singleLine ? content : ''}
+                                                ></th>
                                             );
                                         case 'normal':
                                         default:
-                                            let content = columnItem.headerRender.call(
-                                                this,
-                                                {
-                                                    columnItem
-                                                }
-                                            );
                                             return (
                                                 <th colspan={ columnItem.colSpan }
                                                 rowspan={ columnItem.rowSpan }
                                                 class={columnItem.thClassName}
+                                                title={columnItem.singleLine ? content : ''}
                                                 >
                                                     {content}
                                                 </th>

--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -35,9 +35,7 @@
         text-align: left;
     }
     th {
-        padding: 0 15px;
-        white-space: nowrap;
-        overflow: hidden;
+        padding: 5px 15px;
         text-align: left;
     }
     &-striped {
@@ -52,13 +50,14 @@
         transition: all .3s ease;
     }
     td {
-        padding: 0 15px;
+        padding: 5px 15px;
         word-break: break-all;
     }
     td, th {
         height: 40px;
         vertical-align: middle;
         border-bottom: 1px solid @gray-ddd;
+        box-sizing: border-box;
     }
     &-bordered {
         border: 1px solid @gray-ddd;


### PR DESCRIPTION
1. 修改header初始化样式
默认初始化表头列名只能一行展示，内容过长时展示不全，改为默认多行展示。设置single-line时同时应用到表头列名。
2. 修复列动态赋值内容压盖header问题
当列是动态赋值时(如下代码)，table初始化后内容会压盖表头，导致样式混乱。修改方式为列更新时动态调整`x-table-body-wrapper`的`top`属性
```html
    <x-table class="table-content" :data="sourceData" bordered>
      <x-table-column class-name="column" v-for="column in columns" :key="column.key" :title="column.value" :prop="column.key">
      </x-table-column>
    </x-table>
```